### PR TITLE
Support for Android TV / Gamepads

### DIFF
--- a/material-intro-screen/src/main/java/agency/tango/materialintroscreen/MaterialIntroActivity.java
+++ b/material-intro-screen/src/main/java/agency/tango/materialintroscreen/MaterialIntroActivity.java
@@ -13,6 +13,7 @@ import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.SparseArray;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
@@ -125,6 +126,24 @@ public abstract class MaterialIntroActivity extends AppCompatActivity {
         }
 
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_DPAD_CENTER:
+            case KeyEvent.KEYCODE_ENTER:
+                if (adapter.isLastSlide(viewPager.getCurrentItem())) {
+                    // Finish
+                    onFinish();
+                    finish();
+                } else {
+                    // Go to next
+                    viewPager.setCurrentItem(viewPager.getNextItem());
+                }
+                return true;
+        }
+        return super.onKeyDown(keyCode, event);
     }
 
     @Override

--- a/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragment.java
+++ b/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragment.java
@@ -66,6 +66,7 @@ public class SlideFragment extends ParallaxFragment {
         titleTextView = (TextView) view.findViewById(R.id.txt_title_slide);
         descriptionTextView = (TextView) view.findViewById(R.id.txt_description_slide);
         imageView = (ImageView) view.findViewById(R.id.image_slide);
+        view.requestFocus();
         initializeView();
         return view;
     }

--- a/material-intro-screen/src/main/java/agency/tango/materialintroscreen/widgets/SwipeableViewPager.java
+++ b/material-intro-screen/src/main/java/agency/tango/materialintroscreen/widgets/SwipeableViewPager.java
@@ -56,6 +56,10 @@ public class SwipeableViewPager extends ViewPager {
         return this.getCurrentItem() - 1;
     }
 
+    public int getNextItem() {
+        return this.getCurrentItem() + 1;
+    }
+
     public void setAllowedSwipeDirection(SwipeDirection direction) {
         this.direction = direction;
     }


### PR DESCRIPTION
This adds support for the enter button
to move through slides. It also places
focus on the fragment's main view. From
this, users can move up and down to control
the focus.

Fixes #35