### PR TITLE
Switched isNotNullOrEmpty for (null safe) TextUtils.isEmpty

### DIFF
--- a/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragment.java
+++ b/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -53,10 +54,6 @@ public class SlideFragment extends ParallaxFragment {
 
         slideFragment.setArguments(bundle);
         return slideFragment;
-    }
-
-    public static boolean isNotNullOrEmpty(String string) {
-        return string != null && !string.isEmpty();
     }
 
     @Nullable
@@ -126,7 +123,7 @@ public class SlideFragment extends ParallaxFragment {
 
         if (neededPermissions != null) {
             for (String permission : neededPermissions) {
-                if (isNotNullOrEmpty(permission)) {
+                if (!TextUtils.isEmpty(permission)) {
                     if (ContextCompat.checkSelfPermission(getContext(), permission) != PackageManager.PERMISSION_GRANTED) {
                         notGrantedPermissions.add(permission);
                     }
@@ -135,7 +132,7 @@ public class SlideFragment extends ParallaxFragment {
         }
         if (possiblePermissions != null) {
             for (String permission : possiblePermissions) {
-                if (isNotNullOrEmpty(permission)) {
+                if (!TextUtils.isEmpty(permission)) {
                     if (ContextCompat.checkSelfPermission(getContext(), permission) != PackageManager.PERMISSION_GRANTED) {
                         notGrantedPermissions.add(permission);
                     }
@@ -150,7 +147,7 @@ public class SlideFragment extends ParallaxFragment {
     private boolean hasPermissionsToGrant(String[] permissions) {
         if (permissions != null) {
             for (String permission : permissions) {
-                if (isNotNullOrEmpty(permission)) {
+                if (!TextUtils.isEmpty(permission)) {
                     if (ContextCompat.checkSelfPermission(getContext(), permission) != PackageManager.PERMISSION_GRANTED) {
                         return true;
                     }

--- a/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragment.java
+++ b/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragment.java
@@ -2,6 +2,8 @@ package agency.tango.materialintroscreen;
 
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
@@ -28,8 +30,11 @@ public class SlideFragment extends ParallaxFragment {
     private static final String IMAGE = "image";
     private static final int PERMISSIONS_REQUEST_CODE = 15621;
 
+    @ColorRes
     private int backgroundColor;
+    @ColorRes
     private int buttonsColor;
+    @DrawableRes
     private int image;
     private String title;
     private String description;
@@ -80,10 +85,12 @@ public class SlideFragment extends ParallaxFragment {
         updateViewWithValues();
     }
 
+    @ColorRes
     public int backgroundColor() {
         return backgroundColor;
     }
 
+    @ColorRes
     public int buttonsColor() {
         return buttonsColor;
     }

--- a/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragmentBuilder.java
+++ b/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragmentBuilder.java
@@ -5,12 +5,15 @@ import android.support.annotation.DrawableRes;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class SlideFragmentBuilder {
+    @ColorRes
     int backgroundColor;
+    @ColorRes
     int buttonsColor;
     String title;
     String description;
     String[] neededPermissions;
     String[] possiblePermissions;
+    @DrawableRes
     int image;
 
     public SlideFragmentBuilder backgroundColor(@ColorRes int backgroundColor) {

--- a/material-intro-screen/src/main/java/agency/tango/materialintroscreen/listeners/MessageButtonBehaviourOnPageSelected.java
+++ b/material-intro-screen/src/main/java/agency/tango/materialintroscreen/listeners/MessageButtonBehaviourOnPageSelected.java
@@ -1,5 +1,6 @@
 package agency.tango.materialintroscreen.listeners;
 
+import android.text.TextUtils;
 import android.util.SparseArray;
 import android.view.View;
 import android.view.animation.AnimationUtils;
@@ -9,8 +10,6 @@ import agency.tango.materialintroscreen.MessageButtonBehaviour;
 import agency.tango.materialintroscreen.R;
 import agency.tango.materialintroscreen.SlideFragment;
 import agency.tango.materialintroscreen.adapter.SlidesAdapter;
-
-import static agency.tango.materialintroscreen.SlideFragment.isNotNullOrEmpty;
 
 public class MessageButtonBehaviourOnPageSelected implements IPageSelectedListener {
     private Button messageButton;
@@ -47,7 +46,7 @@ public class MessageButtonBehaviourOnPageSelected implements IPageSelectedListen
     }
 
     private boolean checkIfMessageButtonHasBehaviour(int position) {
-        return messageButtonBehaviours.get(position) != null && isNotNullOrEmpty(messageButtonBehaviours.get(position).getMessageButtonText());
+        return messageButtonBehaviours.get(position) != null && !TextUtils.isEmpty(messageButtonBehaviours.get(position).getMessageButtonText());
     }
 
     private void showMessageButton(final SlideFragment fragment) {


### PR DESCRIPTION
Android has a built in null safe isEmpty for strings. I noticed you weren't using that, and had implemented your own function to do the same thing, so I switched it out for the Android one