### PR TITLE
Add possibility to do async task before transition

### DIFF
--- a/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragment.java
+++ b/material-intro-screen/src/main/java/agency/tango/materialintroscreen/SlideFragment.java
@@ -103,8 +103,24 @@ public class SlideFragment extends ParallaxFragment {
         return hasPermissionsToGrant(neededPermissions);
     }
 
+    public void onNext() {
+
+    }
+
+    public void onBack() {
+
+    }
+
+    public boolean asyncTaskDone() {
+        return true;
+    }
+
     public boolean canMoveFurther() {
         return true;
+    }
+
+    public void moveToNextPage() {
+        ((MaterialIntroActivity)getActivity()).moveToNextPage();
     }
 
     public String cantMoveFurtherErrorMessage() {


### PR DESCRIPTION
Sometimes it might be handy to do async tasks before transition and then
programmatically move to next slide. This could be validation of inputs
in the slide or similar.

In my case it is an e-mail field that needs to be validated towards a server
before the user can move on. And adding a "Validate email"-button for this task
doesn't feel that good from a UI perspective. I.e. I need to contact the server
when the user press the right arrow and the task needs to finish before the user is allowed to continue. 

For this reason I need to know when the user press the back or next buttons, thus I've implemented onNext and onPrev which is called in the fragment slide when that happens.
I also need to be able to block MaterialIntroActivity from continuing to the next slide even though the user pressed the right arrow. This is done by letting asyncTaskDone returning false (default true so the functionality remains the same as in previous commit).

I've done a first rough implementation that fits the above description. Do you think such a feature should/could be included in your lib? If so I need some help from you to clean it up.