### PR TITLE
Added method for getting index of current slide

### DIFF
--- a/material-intro-screen/src/main/java/agency/tango/materialintroscreen/MaterialIntroActivity.java
+++ b/material-intro-screen/src/main/java/agency/tango/materialintroscreen/MaterialIntroActivity.java
@@ -287,6 +287,16 @@ public abstract class MaterialIntroActivity extends AppCompatActivity {
     }
 
     /**
+     * Get index of current slide
+     *
+     * @return index of current slide
+     */
+    @SuppressWarnings("unused")
+    public int getCurrentSlideIndex() {
+        return viewPager.getCurrentItem();
+    }
+
+    /**
      * Set if last screen should be able to exit with alpha transition
      *
      * @param enableAlphaExitTransition should enable alpha exit transition


### PR DESCRIPTION
I added an intro activity to my app, but I realized that if the user presses the back button while viewing the first slide, the activity will simply close. This is a problem if the user needs to grant permissions, accept terms and conditions, etc.

Using the proposed method getCurrentSlideIndex(), I could do something like this in my intro activity:

```
@Override
public void onBackPressed() {
    if (getCurrentSlideIndex() != 0) {
        super.onBackPressed()
    }
}
```